### PR TITLE
Extend LOG003 disallowed `extra` keys to include `message`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+* Extend LOG003 disallowed ``extra`` keys to include ``message``.
+
+  Thanks to Bartek Ogryczak in `PR #77 <https://github.com/adamchainz/flake8-logging/pull/77>`__.
+
 1.4.0 (2023-10-10)
 ------------------
 

--- a/src/flake8_logging/__init__.py
+++ b/src/flake8_logging/__init__.py
@@ -51,6 +51,7 @@ logrecord_attributes = frozenset(
         "levelname",
         "levelno",
         "lineno",
+        "message",
         "module",
         "msecs",
         "msg",

--- a/tests/test_flake8_logging.py
+++ b/tests/test_flake8_logging.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import ast
+import logging
 import re
 import sys
 from importlib.metadata import version
 from textwrap import dedent
-import logging
 
 import pytest
 

--- a/tests/test_flake8_logging.py
+++ b/tests/test_flake8_logging.py
@@ -5,6 +5,7 @@ import re
 import sys
 from importlib.metadata import version
 from textwrap import dedent
+import logging
 
 import pytest
 
@@ -243,6 +244,7 @@ class TestLOG002:
 
 
 class TestLOG003:
+
     def test_module_call(self):
         results = run(
             """\
@@ -253,6 +255,32 @@ class TestLOG003:
 
         assert results == [
             (2, 26, "LOG003 extra key 'msg' clashes with LogRecord attribute")
+        ]
+
+    @pytest.mark.parametrize("key", logging.makeLogRecord({}).__dict__.keys())
+    def test_module_call_logrecord_keys(self, key):
+        results = run(
+            f"""\
+            import logging
+            logging.info("Hi", extra={{"{key}": "Ho"}})
+            """
+        )
+
+        assert results == [
+            (2, 26, f"LOG003 extra key '{key}' clashes with LogRecord attribute")
+        ]
+
+    @pytest.mark.parametrize("key", ["asctime", "message"])
+    def test_module_call_formatter_keys(self, key):
+        results = run(
+            f"""\
+            import logging
+            logging.info("Hi", extra={{"{key}": "Ho"}})
+            """
+        )
+
+        assert results == [
+            (2, 26, f"LOG003 extra key '{key}' clashes with LogRecord attribute")
         ]
 
     def test_module_call_debug(self):
@@ -420,6 +448,8 @@ class TestLOG003:
         assert results == [
             (3, 29, "LOG003 extra key 'msg' clashes with LogRecord attribute")
         ]
+
+
 
 
 class TestLOG004:

--- a/tests/test_flake8_logging.py
+++ b/tests/test_flake8_logging.py
@@ -244,7 +244,6 @@ class TestLOG002:
 
 
 class TestLOG003:
-
     def test_module_call(self):
         results = run(
             """\

--- a/tests/test_flake8_logging.py
+++ b/tests/test_flake8_logging.py
@@ -450,8 +450,6 @@ class TestLOG003:
         ]
 
 
-
-
 class TestLOG004:
     def test_module_call(self):
         results = run(


### PR DESCRIPTION
`LogRecord` specifically disallows two `Formatter`'s params `"message"` and `"asctime"` in `extra`:
https://github.com/python/cpython/blob/d07483292b115a5a0e9b9b09f3ec1000ce879986/Lib/logging/__init__.py#L1621-L1623

This PR adds missing `"message"` missing in `LOG003` check.
This will prevent 
```
KeyError "Attempt to overwrite 'message' in LogRecord"
```

Also added parametrized tests which validate _all_ the keys that should be rejected by LOG003. 
