### PR TITLE
Add typos tool to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,18 @@ repos:
   - id: check-toml
   - id: end-of-file-fixer
   - id: trailing-whitespace
+- repo: https://github.com/crate-ci/typos
+  rev: 6cb49915af2e93e61f5f0d0a82216e28ad5c7c18  # frozen: v1
+  hooks:
+  - id: typos
+    exclude: |
+      (?x)^(
+        .*\.min\.css
+        |.*\.min\.js
+        |.*\.css\.map
+        |.*\.js\.map
+        |.*\.svg
+      )$
 - repo: https://github.com/tox-dev/pyproject-fmt
   rev: 57b6ff7bf72affdd12c7f3fd6de761ba18a33b3a  # frozen: v2.5.1
   hooks:

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,10 @@
+# Configuration file for 'typos' tool
+# https://github.com/crate-ci/typos
+
+[default]
+extend-ignore-re = [
+  # Single line ignore comments
+  "(?Rm)^.*(#|//)\\s*typos: ignore$",
+  # Multi-line ignore comments
+  "(?s)(#|//)\\s*typos: off.*?\\n\\s*(#|//)\\s*typos: on"
+]

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -56,7 +56,7 @@ Changelog
 
 * LOG001: Avoid detecting inside function definitions when using ``Logger`` directly.
 
-* Add rule LOG005 that recomends ``exception()`` over ``error()`` within ``except`` clauses.
+* Add rule LOG005 that recommends ``exception()`` over ``error()`` within ``except`` clauses.
 
 * Add rule LOG006 that detects redundant ``exc_info`` arguments in calls to ``exception()``.
 

--- a/README.rst
+++ b/README.rst
@@ -100,7 +100,7 @@ __ https://docs.python.org/3/reference/import.html?#name__
 
 This rule detects probably-mistaken usage of similar module-level dunder constants:
 
-* |__cached__|__ - the pathname of the module’s compiled versio˜, such as ``camelot/__pycache__/spam.cpython-311.pyc``.
+* |__cached__|__ - the pathname of the module’s compiled version˜, such as ``camelot/__pycache__/spam.cpython-311.pyc``.
 
   .. |__cached__| replace:: ``__cached__``
   __ https://docs.python.org/3/reference/import.html?#cached__
@@ -496,7 +496,7 @@ When using named ``%``-style formatting, if the message references a missing key
 
 .. code-block:: pycon
 
-    >>> logging.error("Hi %(name)s", {"nam": "hacker"})
+    >>> logging.error("Hi %(name)s", {"nom": "hacker"})
     --- Logging error ---
     Traceback (most recent call last):
       File "/.../logging/__init__.py", line 1160, in emit
@@ -511,7 +511,7 @@ When using named ``%``-style formatting, if the message references a missing key
     Call stack:
       File "<stdin>", line 1, in <module>
     Message: 'Hi %(name)s'
-    Arguments: {'nam': 'hacker'}
+    Arguments: {'nom': 'hacker'}
 
 This will only happen when the logger is enabled since loggers don’t perform string formatting when disabled.
 Thus a configuration change can reveal such errors.

--- a/tests/test_flake8_logging.py
+++ b/tests/test_flake8_logging.py
@@ -136,7 +136,7 @@ class TestLOG001:
     def test_direct_aliased(self):
         results = run(
             """\
-            from loggin import Logger as _Logger
+            from logging import Logger as _Logger
             _Logger("x")
             """
         )


### PR DESCRIPTION
This tool corrects common misspellings in all kinds of text files.