### PR TITLE
Add LOG016 to detect set literals passed where dict expected (#186)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,9 @@ Changelog
 
 * Drop Python 3.9 support.
 
+* Add rule LOG016 that detects set literals passed as arguments where a dict
+  is expected for ``%``-style named formatting.
+
 1.8.0 (2025-09-09)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -601,3 +601,46 @@ Corrected:
     logger = logging.getLogger(__name__)
 
     logger.info("hello world")
+
+LOG016 formatting error: set passed where dict expected
+-------------------------------------------------------
+
+When using named ``%``-style formatting, the arguments must be passed as a dict.
+A common typo is writing ``{"key", value}`` (a set literal with a comma) instead of ``{"key": value}`` (a dict literal with a colon).
+Since Python's ``{expr, expr}`` syntax creates a valid set, no syntax error is raised, and the bug only surfaces at runtime when the log statement is actually executed:
+
+.. code-block:: pycon
+
+    >>> logging.error("Hi %(name)s", {"name", "hacker"})
+    --- Logging error ---
+    Traceback (most recent call last):
+      File "/.../logging/__init__.py", line 1160, in emit
+        msg = self.format(record)
+              ^^^^^^^^^^^^^^^^^^^
+    ...
+
+      File "/.../logging/__init__.py", line 392, in getMessage
+        msg = msg % self.args
+              ~~~~^~~~~~~~~~~
+    TypeError: format requires a mapping
+    Call stack:
+      File "<stdin>", line 1, in <module>
+    Message: 'Hi %(name)s'
+    Arguments: ({'hacker', 'name'},)
+
+This will only happen when the logger is enabled since loggers don't perform string formatting when disabled.
+Thus a configuration change can reveal such errors.
+
+This rule detects set literals passed where a dict argument is expected for ``%``-style named formatting.
+
+Failing example:
+
+.. code-block:: python
+
+    logging.info("Blending %(fruit)s", {"fruit", fruit})
+
+Corrected:
+
+.. code-block:: python
+
+    logging.info("Blending %(fruit)s", {"fruit": fruit})

--- a/src/flake8_logging/__init__.py
+++ b/src/flake8_logging/__init__.py
@@ -126,6 +126,7 @@ LOG012 = "LOG012 formatting error: {n} {style} placeholder{ns} but {m} argument{
 LOG013 = "LOG013 formatting error: {mistake} key{ns}: {keys}"
 LOG014 = "LOG014 avoid exc_info=True outside of exception handlers"
 LOG015 = "LOG015 avoid logging calls on the root logger"
+LOG016 = "LOG016 formatting error: set passed where dict expected"
 
 
 class Visitor(ast.NodeVisitor):
@@ -473,6 +474,28 @@ class Visitor(ast.NodeVisitor):
                         m=arg_count,
                         ms="s" if arg_count != 1 else "",
                     ),
+                )
+            )
+            return
+
+        # LOG016: set literal where dict expected (e.g. {"key", val}
+        # instead of {"key": val}). Checked after LOG013/LOG012
+        # because ast.Set falls through both: it's not ast.Dict, and
+        # named placeholders don't count as positional.
+        if (
+            (
+                (node.func.attr != "log" and (dict_idx := 1))
+                or (node.func.attr == "log" and (dict_idx := 2))
+            )
+            and len(node.args) == dict_idx + 1
+            and isinstance(node.args[dict_idx], ast.Set)
+            and modnamed_placeholder_re().search(msg)
+        ):
+            self.errors.append(
+                (
+                    node.args[dict_idx].lineno,
+                    node.args[dict_idx].col_offset,
+                    LOG016,
                 )
             )
             return

--- a/tests/test_flake8_logging.py
+++ b/tests/test_flake8_logging.py
@@ -1735,6 +1735,146 @@ class TestLOG015:
         assert results == []
 
 
+class TestLOG016:
+    msg = (
+        "LOG016 formatting error:"
+        " set passed where dict expected"
+    )
+
+    def test_module_call(self):
+        results = run_ignore_log015(
+            """\
+            import logging
+            logging.info("Blending %(fruit)s", {"fruit", fruit})
+            """
+        )
+
+        assert results == [
+            (2, 35, self.msg),
+        ]
+
+    def test_attr_call(self):
+        results = run_ignore_log015(
+            """\
+            import logging
+            logger = logging.getLogger(__name__)
+            logger.info("Blending %(fruit)s", {"fruit", fruit})
+            """
+        )
+
+        assert results == [
+            (3, 34, self.msg),
+        ]
+
+    def test_module_call_log(self):
+        results = run_ignore_log015(
+            """\
+            import logging
+            logging.log(
+                logging.INFO,
+                "Blending %(fruit)s",
+                {"fruit", fruit},
+            )
+            """
+        )
+
+        assert results == [
+            (5, 4, self.msg),
+        ]
+
+    def test_attr_call_log(self):
+        results = run_ignore_log015(
+            """\
+            import logging
+            logger = logging.getLogger(__name__)
+            logger.log(
+                logging.INFO,
+                "Blending %(fruit)s",
+                {"fruit", fruit},
+            )
+            """
+        )
+
+        assert results == [
+            (6, 4, self.msg),
+        ]
+
+    def test_multiline(self):
+        results = run_ignore_log015(
+            """\
+            import logging
+            logging.info(
+                "Blending %(fruit)s",
+                {"fruit", fruit},
+            )
+            """
+        )
+
+        assert results == [
+            (4, 4, self.msg),
+        ]
+
+    def test_multiple_placeholders(self):
+        results = run_ignore_log015(
+            """\
+            import logging
+            logging.info(
+                "Blending %(fruit)s %(colour)s",
+                {"fruit", fruit, "colour", colour},
+            )
+            """
+        )
+
+        assert results == [
+            (4, 4, self.msg),
+        ]
+
+    def test_concat_format_string(self):
+        results = run_ignore_log015(
+            """\
+            import logging
+            logging.info(
+                "Blending %(fruit)" + "s",
+                {"fruit", fruit},
+            )
+            """
+        )
+
+        assert results == [
+            (4, 4, self.msg),
+        ]
+
+    def test_positional_placeholder_with_set_arg(self):
+        results = run_ignore_log015(
+            """\
+            import logging
+            logging.info("Blending %s", {a, b})
+            """
+        )
+
+        assert results == []
+
+    def test_no_placeholders_with_set_arg(self):
+        results = run_ignore_log015(
+            """\
+            import logging
+            logging.info("Blending", {"a", b})
+            """
+        )
+
+        assert results == []
+
+    def test_dict_arg(self):
+        results = run_ignore_log015(
+            """\
+            import logging
+            logging.info("Blending %(fruit)s", {"fruit": fruit})
+            """
+        )
+
+        assert results == []
+
+
 class TestFlattenStrChain:
     def run(self, source: str) -> str | None:
         tree = ast.parse(dedent(source))

--- a/tests/test_flake8_logging.py
+++ b/tests/test_flake8_logging.py
@@ -1736,10 +1736,7 @@ class TestLOG015:
 
 
 class TestLOG016:
-    msg = (
-        "LOG016 formatting error:"
-        " set passed where dict expected"
-    )
+    msg = "LOG016 formatting error: set passed where dict expected"
 
     def test_module_call(self):
         results = run_ignore_log015(


### PR DESCRIPTION
Named %-style format strings like "%(key)s" require a dict argument, but {"key", value} (comma instead of colon) silently creates a set. This causes TypeError at runtime only when the log statement is actually executed, making it easy to miss.

Addresses #186 

Assisted-by: Claude claude-opus-4-6 claude-code/2.1.193